### PR TITLE
Modify channel to publish to durable topic exchange and dynamic routing key

### DIFF
--- a/conf/appdata/configuration.properties
+++ b/conf/appdata/configuration.properties
@@ -1,4 +1,4 @@
-AMQP_EXCHANGE = fabric.interfaceengine
+AMQP_EXCHANGE_NAME = fabric.realtime.hl7
+AMQP_EXCHANGE_TYPE = topic
 AMQP_HOST = rabbitmq
-AMQP_ROUTING_KEY = mirth.connect.inbound
 AMQP_PORT = 5672

--- a/conf/channels/Realtime_HL7V2_Processor.xml
+++ b/conf/channels/Realtime_HL7V2_Processor.xml
@@ -5,10 +5,10 @@
   <description></description>
   <enabled>true</enabled>
   <lastModified>
-    <time>1506118761570</time>
+    <time>1506638294857</time>
     <timezone>America/Denver</timezone>
   </lastModified>
-  <revision>4</revision>
+  <revision>10</revision>
   <sourceConnector version="3.4.2">
     <metaDataId>0</metaDataId>
     <name>sourceConnector</name>
@@ -535,10 +535,11 @@ factory.setHost($(&apos;AMQP_HOST&apos;));
 factory.setPort(parseInt($(&apos;AMQP_PORT&apos;)));
 var connection = factory.newConnection();
 var channel = connection.createChannel();
-channel.exchangeDeclare($(&apos;AMQP_EXCHANGE&apos;), &quot;direct&quot;);
+channel.exchangeDeclare($(&apos;AMQP_EXCHANGE_NAME&apos;), $(&apos;AMQP_EXCHANGE_TYPE&apos;), true);
 
-channel.basicPublish($(&apos;AMQP_EXCHANGE&apos;), 
-	$(&apos;AMQP_ROUTING_KEY&apos;), 
+var routingKey = $(&apos;Protocol&apos;)+&quot;.&quot; + $(&apos;MessageType&apos;) + &quot;.&quot; + $(&apos;MessageEvent&apos;);
+channel.basicPublish($(&apos;AMQP_EXCHANGE_NAME&apos;), 
+	routingKey, 
 	Packages.com.rabbitmq.client.MessageProperties.PERSISTENT_TEXT_PLAIN, 
 	JsonUtil.prettyPrint(JSON.stringify(messagePayload)).getBytes());</script>
       </properties>
@@ -550,7 +551,7 @@ channel.basicPublish($(&apos;AMQP_EXCHANGE&apos;),
           <serializationProperties class="com.mirth.connect.plugins.datatypes.hl7v2.HL7v2SerializationProperties" version="3.4.2">
             <handleRepetitions>true</handleRepetitions>
             <handleSubcomponents>true</handleSubcomponents>
-            <useStrictParser>false</useStrictParser>
+            <useStrictParser>true</useStrictParser>
             <useStrictValidation>false</useStrictValidation>
             <stripNamespaces>true</stripNamespaces>
             <segmentDelimiter>\r</segmentDelimiter>
@@ -587,7 +588,7 @@ channel.basicPublish($(&apos;AMQP_EXCHANGE&apos;),
         </inboundProperties>
         <outboundProperties class="com.mirth.connect.plugins.datatypes.xml.XMLDataTypeProperties" version="3.4.2">
           <serializationProperties class="com.mirth.connect.plugins.datatypes.xml.XMLSerializationProperties" version="3.4.2">
-            <stripNamespaces>true</stripNamespaces>
+            <stripNamespaces>false</stripNamespaces>
           </serializationProperties>
           <batchProperties class="com.mirth.connect.plugins.datatypes.xml.XMLBatchProperties" version="3.4.2">
             <splitType>Element_Name</splitType>

--- a/conf/channels/Realtime_HL7V2_Processor.xml
+++ b/conf/channels/Realtime_HL7V2_Processor.xml
@@ -5,10 +5,10 @@
   <description></description>
   <enabled>true</enabled>
   <lastModified>
-    <time>1506638294857</time>
+    <time>1506642678248</time>
     <timezone>America/Denver</timezone>
   </lastModified>
-  <revision>10</revision>
+  <revision>24</revision>
   <sourceConnector version="3.4.2">
     <metaDataId>0</metaDataId>
     <name>sourceConnector</name>
@@ -514,7 +514,8 @@ NjVeOTl8THx8fEZ8fHwyMDA2MTEyMjE1NDczM3w=</inboundTemplate>
           </resourceIds>
           <queueBufferSize>1000</queueBufferSize>
         </destinationConnectorProperties>
-        <script>var messagePayload = { 
+        <script>var ts = java.time.Instant.now().toString();
+var messagePayload = { 
 	Protocol:  $(&apos;Protocol&apos;), 
 	Version: $(&apos;Version&apos;),
 	SendingApplication: $(&apos;SendingApplication&apos;),
@@ -525,8 +526,7 @@ NjVeOTl8THx8fEZ8fHwyMDA2MTEyMjE1NDczM3w=</inboundTemplate>
 	MessageType: $(&apos;MessageType&apos;), 
 	MessageEvent: $(&apos;MessageEvent&apos;), 
 	MessageHash: $(&apos;MessageHash&apos;), 
-	TransmissionReceiptTimeInMillis: $(&apos;TransmissionReceiptTimeInMillis&apos;),
-	Filename: $(&apos;originalFilename&apos;), 
+	TransmissionReceiptTime: ts,
 	RawMessage: connectorMessage.getRawData(), 
 	XmlMessage: connectorMessage.getEncodedData() };
 
@@ -545,6 +545,8 @@ channel.basicPublish($(&apos;AMQP_EXCHANGE_NAME&apos;),
       </properties>
       <transformer version="3.4.2">
         <steps/>
+        <inboundTemplate encoding="base64"></inboundTemplate>
+        <outboundTemplate encoding="base64"></outboundTemplate>
         <inboundDataType>HL7V2</inboundDataType>
         <outboundDataType>XML</outboundDataType>
         <inboundProperties class="com.mirth.connect.plugins.datatypes.hl7v2.HL7v2DataTypeProperties" version="3.4.2">


### PR DESCRIPTION
Modify channel to publish to a durable topic exchange. Also, to build the routing key dynamically to be <protocol>.<message-type>.<event-type> (e.g. 'HL7.ADT.A01'). Update configuration properties for exchange. The destination now serializes to the strict HL7 XML format which matches the nHapi schema as well as structures which match the HL7 specifications.